### PR TITLE
node version to 20 and go to 1.20 for runners of workflows

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.20.0
+          go-version: 1.20
       - name: Download OpenAPI generator
         run: |
           generatorUrl=$(cat ${{ github.workspace }}/bindgen-config.json | json generate.generatorUrl)

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 20
       - name: Install json CLI
         run: npm install -g json
       - name: Set up JDK 1.8
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.18.3
+          go-version: 1.20.0
       - name: Download OpenAPI generator
         run: |
           generatorUrl=$(cat ${{ github.workspace }}/bindgen-config.json | json generate.generatorUrl)

--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.18.3
+          go-version: 1.20.0
       - name: Run all tests
         run: |
          export ONSHAPE_BASE_URL=https://demo-c.dev.onshape.com

--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.20.0
+          go-version: 1.20
       - name: Run all tests
         run: |
          export ONSHAPE_BASE_URL=https://demo-c.dev.onshape.com

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 20
       - name: Install json CLI
         run: npm install -g json
       - name: Fetch specification


### PR DESCRIPTION
**Problem:**
- Version of go is 1.18.3 for the runner of the tests and the build. Go-client is using 1.20, however.
- Version of node is 14 which is outdated at this point.

**Fix:**
- Pumped version of go to 1.20
- Pumped version of node to 20

**Effect:**
- No more the following warning: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-go@v3.2.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`