### PR TITLE
CGM-1740: update go mods in github workflows

### DIFF
--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -27,6 +27,7 @@ jobs:
          go get -u ./...
          go mod tidy
          if [[ $(git status --porcelain go.mod go.sum) ]]; 
-            git commit -a -m "updated go mods"
+            git add go.mod go.sum
+            git commit -m "updated go mods"
          fi
          go test ${{ github.workspace }}/...

--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -24,4 +24,9 @@ jobs:
          export ONSHAPE_BASE_URL=https://demo-c.dev.onshape.com
          export ONSHAPE_API_ACCESS_KEY=${{ secrets.ONSHAPE_API_ACCESS_KEY }}
          export ONSHAPE_API_SECRET_KEY=${{ secrets.ONSHAPE_API_SECRET_KEY }}
+         go get -u ./...
+         go mod tidy
+         if [[ $(git status --porcelain go.mod go.sum) ]]; 
+            git commit -a -m "updated go mods"
+         fi
          go test ${{ github.workspace }}/...


### PR DESCRIPTION
**Problem:**
- The project depends on the manual updating of the go modules.

**Fix:**
- Modules are updated every time the reusable workflow at test-bindings.yml is used

**Effect:**
- Go mods are always up to date providing utmost mod security, latest bug fixes, etc.
