### PR TITLE
revert node and go version upgrade

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 14
       - name: Install json CLI
         run: npm install -g json
       - name: Set up JDK 1.8
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.20
+          go-version: 1.18.3
       - name: Download OpenAPI generator
         run: |
           generatorUrl=$(cat ${{ github.workspace }}/bindgen-config.json | json generate.generatorUrl)

--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.20
+          go-version: 1.18.3
       - name: Run all tests
         run: |
          export ONSHAPE_BASE_URL=https://demo-c.dev.onshape.com

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 14
       - name: Install json CLI
         run: npm install -g json
       - name: Fetch specification


### PR DESCRIPTION
Problem:
- Generate bindings fail. Testing the change was never done before other commits were added.

After merge to test, we will manually trigger go-client generate-bindings workflow:
- If successful, version upgrade is the cause of the current workflow failure
- Else, inconclusive