### PR TITLE
reverting the automatic mod updates

### DIFF
--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -24,10 +24,4 @@ jobs:
          export ONSHAPE_BASE_URL=https://demo-c.dev.onshape.com
          export ONSHAPE_API_ACCESS_KEY=${{ secrets.ONSHAPE_API_ACCESS_KEY }}
          export ONSHAPE_API_SECRET_KEY=${{ secrets.ONSHAPE_API_SECRET_KEY }}
-         go get -u ./...
-         go mod tidy
-         if [[ $(git status --porcelain go.mod go.sum) ]]; 
-            git add go.mod go.sum
-            git commit -m "updated go mods"
-         fi
          go test ${{ github.workspace }}/...


### PR DESCRIPTION
Problem:
- go mod updating automatically showed a hidden problem in the workflow: inconsistent go version in different parts of the projects.

Next step:
- upgrade go version, openapi generator and implement changes in the workflow in a consistent manner