### PR TITLE
Removes hardcoded branch

### DIFF
--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -151,6 +151,6 @@ jobs:
         if: (steps.gb.outputs.changes-occurred && steps.wait-for-build.outputs.conclusion == 'success')
         run: |
           git fetch --all
-          git reset --hard origin/master
+          git reset --hard origin/${{ github.ref_name }}
           git tag -f v${{ steps.ps.outputs.change }}
           git push -f origin --tags


### PR DESCRIPTION
This is required to fix the automatic generation in the go-client-internal repo.